### PR TITLE
Fix saveBugReport function name, saveReport in bugpilot-integration.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugpilot/react-error-pages",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "description": "A Collection of reusable React Error Pages",
   "main": "dist/index.mjs",
   "scripts": {

--- a/src/lib/bugpilot-integration.ts
+++ b/src/lib/bugpilot-integration.ts
@@ -56,7 +56,7 @@ export const updateBugReport = (reportData: ReportData) => {
 
 export const saveBugReport = () => {
   waitForBugpilot((bugpilot) => {
-    void bugpilot.saveBugReport(
+    void bugpilot.saveReport?.(
       {
         triggerType: "error-page",
       },

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ type Report = {
 };
 
 export type BugpilotInterface = {
-  saveBugReport: (...args: unknown[]) => void;
+  saveReport: (...args: unknown[]) => void;
   identify: (...args: unknown[]) => void;
   report?: Report;
   logout: () => void;


### PR DESCRIPTION
This pull request fixes the function name `saveBugReport` to `saveReport` in the `bugpilot-integration.ts` file.