### PR TITLE
do not use reset()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugpilot/react-error-pages",
-  "version": "1.18.3",
+  "version": "1.19.0",
   "description": "A Collection of reusable React Error Pages",
   "main": "dist/index.mjs",
   "scripts": {

--- a/src/themes/basic/error.tsx
+++ b/src/themes/basic/error.tsx
@@ -10,7 +10,9 @@ import { ErrorPageProps } from "../../types";
 import { saveBugReport } from "@/lib/bugpilot-integration";
 
 export default function Component({
-  reset,
+  // NOTE: We have seen inconsistent behavior with the reset function in next 14.1.0+ so we are
+  // commenting it out for now. Using window.location.reload() instead.
+  // reset,
   onAddDetailsClick,
   reportErrorFn,
   error,
@@ -32,7 +34,7 @@ export default function Component({
       </p>
 
       <div className="flex flex-col gap-2 min-[400px]:flex-row">
-        <Button variant="default" onClick={() => reset()}>
+        <Button variant="default" onClick={() => window.location.reload()}>
           Try again
         </Button>
 


### PR DESCRIPTION
We prefer doing a full page reload instead of calling reset. This applies only to the error.tsx boundary.
In some cases, it may pollute the global CSS (in case of an error).